### PR TITLE
Add Node 8 as part of the testing environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ cache:
 notifications:
   email: false
 node_js:
+  - '8'
   - '7'
   - '6'
 after_success:


### PR DESCRIPTION
Adding Node 8 to the testing environment makes sure that this preset works with versions Node 6, 7, and 8.